### PR TITLE
Enhance Makefile to include ISO image creation and cleanup commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,36 @@ boot.o: boot.s
 	nasm $(NASMPARAMS) boot.s -o boot.o
 
 kernel.o: kernel.c
+	@echo "[+] Compiling kernel.c"
 	gcc -m32 -ffreestanding -c kernel.c -o kernel.o
 
 kernel.bin: linker.ld $(OBJ_FILES)
-
 	@echo "[+] Building LinuxFromScratch"
 	@echo "[+] ..."
 	@echo " "
 	ld $(LDPARAMS) -T linker.ld -o kernel.bin $(OBJ_FILES)
 	@echo "[+] Succesfully builded."
 
+iso: kernel.bin
+	@echo "[+] Creating ISO image"
+	mkdir -p iso/boot/grub
+	cp kernel.bin iso/boot/
+	echo 'set timeout=0' > iso/boot/grub/grub.cfg
+	echo 'set default=0' >> iso/boot/grub/grub.cfg
+	echo 'menuentry "LinuxFromScratch" {' >> iso/boot/grub/grub.cfg
+	echo '  multiboot /boot/kernel.bin' >> iso/boot/grub/grub.cfg
+	echo '}' >> iso/boot/grub/grub.cfg
+	grub-mkrescue -o dorykernel.iso iso
+	rm -rf iso
+	mv dorykernel.iso LinuxFromScratch
+	@echo "[+] ISO image created"
+
+clean:
+	@echo "[+] Cleaning up"
+	rm -f *.o kernel.bin
+	rm -f LinuxFromScratch/*.iso
+	@echo "[+] Done."
+
+run: kernel.bin
+	@echo "[+] Running LinuxFromScratch"
+	qemu-system-i386 -kernel kernel.bin

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,83 @@
-sudo apt-get install xorriso
-sudo apt-get install grub
-sudo apt-get install gcc
-sudo apt-get install nasm 
+#!/bin/bash
+# filepath: /home/guilh/Documents/Programming/C/LinuxFromScratch/build.sh
+
+# Define colors for better output lol
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+echo -e "${BLUE}=== Linux From Scratch Development Environment Setup ===${NC}"
+echo -e "${YELLOW}Detecting operating system...${NC}"
+
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    OS=$ID
+else
+    echo -e "${RED}Cannot detect operating system. Exiting.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}Detected $OS distribution${NC}"
+
+command_exists() {
+    command -v "$1" &> /dev/null
+}
+
+install_packages() {
+    echo -e "${YELLOW}Installing required dependencies...${NC}"
+
+    case $OS in
+        ubuntu|debian)
+            sudo apt-get update
+            sudo apt-get install -y gcc xorriso grub-common grub2-common grub-pc \
+                                   nasm qemu-system-x86 build-essential
+            ;;
+        fedora)
+            sudo dnf update
+            sudo dnf install -y gcc xorriso grub2 grub2-tools \
+                              nasm qemu-system-x86 make
+            ;;
+        arch|manjaro)
+            sudo pacman -Syu
+            sudo pacman -S --noconfirm gcc xorriso grub \
+                                      nasm qemu make
+            ;;
+        *)
+            echo -e "${RED}Unsupported operating system: $OS${NC}"
+            echo -e "${YELLOW}Please install the following packages manually:${NC}"
+            echo "  - gcc (C compiler)"
+            echo "  - xorriso (ISO creator)"
+            echo "  - grub (bootloader)"
+            echo "  - nasm (assembler)"
+            echo "  - qemu (emulator)"
+            echo "  - make (build tool)"
+            exit 1
+            ;;
+    esac
+
+    echo -e "${GREEN}Dependencies installed successfully!${NC}"
+}
+
+echo -e "${YELLOW}Checking for required tools...${NC}"
+
+MISSING_TOOLS=false
+
+for tool in gcc nasm make xorriso qemu-system-i386; do
+    if command_exists $tool; then
+        echo -e "${GREEN}✓ $tool is installed${NC}"
+    else
+        echo -e "${RED}✗ $tool is not installed${NC}"
+        MISSING_TOOLS=true
+    fi
+done
+
+if [ "$MISSING_TOOLS" = true ]; then
+    install_packages
+else
+    echo -e "${GREEN}All required tools are already installed!${NC}"
+fi
+
+echo -e "${BLUE}Setup complete! You can now build your kernel using 'make' command.${NC}"
+echo -e "${YELLOW}Tip: Use 'make iso' to create a bootable ISO image.${NC}"


### PR DESCRIPTION
This pull request introduces several enhancements to the `Makefile` for the LinuxFromScratch project, including new targets for creating an ISO image, cleaning up build artifacts, and running the kernel using QEMU. Additionally, it adds echo statements to improve the build process's clarity.

Enhancements to the `Makefile`:

* Added a new `iso` target to create an ISO image of the kernel, including the necessary GRUB configuration and cleanup steps.
* Introduced a `clean` target to remove build artifacts like object files and the ISO image, ensuring a clean build environment.
* Added a `run` target to execute the kernel using QEMU, facilitating easy testing of the built kernel.
* Included echo statements in the `kernel.o` and `kernel.bin` targets to provide feedback during the compilation and linking stages.